### PR TITLE
[fix] Dimmer issue when controlling device from Homekit

### DIFF
--- a/src/setFunctions.ts
+++ b/src/setFunctions.ts
@@ -75,7 +75,11 @@ export class SetFunctions {
       }
       this.setGlobalVariable(IDs[1], value === true ? '100' : '0');
     } else {
-      await this.command(value === false ? 'turnOff' : 'turnOn', null, service, IDs);
+      if (!service.isNotTurnOn) {
+        await this.command(value ? 'turnOn' : 'turnOff', null, service, IDs);
+      } else {
+        service.isNotTurnOn = false;
+      }
     }
   }
 
@@ -83,6 +87,7 @@ export class SetFunctions {
     if (service.isGlobalVariableDimmer) {
       await this.setGlobalVariable(IDs[1], value.toString());
     } else {
+      service.isNotTurnOn = (value > 0);
       await this.command('setValue', [value], service, IDs);
     }
   }


### PR DESCRIPTION
Fixed a bug where when adjusting the dimming level, the dimmers jump to the selected level and then return to the original dimming level.